### PR TITLE
POC for making a docstring MLJ compliant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,16 +7,18 @@ version = "0.1.3"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 OutlierDetectionInterface = "1722ece6-f894-4ffc-b6be-6ca1174e2011"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "1"
 Combinatorics = "1.0"
 Distances = "0.10"
-OutlierDetectionInterface = "0.1"
+MLJModelInterface = "1.8"
 NearestNeighbors = "0.4"
+OutlierDetectionInterface = "0.1"
+julia = "1"
 
 [extras]
 OutlierDetectionTest = "66620973-d34b-445b-a614-4040704cad69"

--- a/src/OutlierDetectionNeighbors.jl
+++ b/src/OutlierDetectionNeighbors.jl
@@ -4,6 +4,7 @@ module OutlierDetectionNeighbors
     const OD = OutlierDetectionInterface
 
     import NearestNeighbors
+    import MLJModelInterface
     const NN = NearestNeighbors
 
     import Distances
@@ -12,9 +13,10 @@ module OutlierDetectionNeighbors
     include("utils.jl")
     include("models/abod.jl")
     include("models/cof.jl")
-    include("models/dnn.jl") 
+    include("models/dnn.jl")
     include("models/knn.jl")
     include("models/lof.jl")
+    include("models/docstrings.jl")
 
     const UUID = "51249a0a-cb36-4849-8e04-30c7f8d311bb"
     const MODELS = [:ABODDetector,

--- a/src/models/abod.jl
+++ b/src/models/abod.jl
@@ -2,42 +2,6 @@ using Combinatorics: combinations
 using LinearAlgebra: dot, norm
 using Statistics: var
 
-"""
-    ABODDetector(k = 5,
-                 metric = Euclidean(),
-                 algorithm = :kdtree,
-                 static = :auto,
-                 leafsize = 10,
-                 reorder = true,
-                 parallel = false,
-                 enhanced = false)
-
-Determine outliers based on the angles to its nearest neighbors. This implements the `FastABOD` variant described in
-the paper, that is, it uses the variance of angles to its nearest neighbors, not to the whole dataset, see [1]. 
-
-*Notice:* The scores are inverted, to conform to our notion that higher scores describe higher outlierness.
-
-Parameters
-----------
-$K_PARAM
-
-$KNN_PARAMS
-
-    enhanced::Bool
-When `enhanced=true`, it uses the enhanced ABOD (EABOD) adaptation proposed by [2].
-
-Examples
---------
-$(SCORE_UNSUPERVISED("ABODDetector"))
-
-References
-----------
-[1] Kriegel, Hans-Peter; S hubert, Matthias; Zimek, Arthur (2008): Angle-based outlier detection in high-dimensional
-data.
-
-[2] Li, Xiaojie; Lv, Jian Cheng; Cheng, Dongdong (2015): Angle-Based Outlier Detection Algorithm with More Stable
-Relationships.
-"""
 OD.@detector mutable struct ABODDetector <: UnsupervisedDetector
     # Note: the minimum k is 3. The 2 nearest neighbors yields one angle, which implies zero variance everywhere.
     k::Integer = 5::(_ > 2)

--- a/src/models/docstrings.jl
+++ b/src/models/docstrings.jl
@@ -1,0 +1,85 @@
+# # HELPERS
+
+# header for mlj part of document strings
+mlj_header(T) =
+    """
+    # MLJ Interface
+
+    $MLJModelInterface.doc_header(T, augment=true))
+
+    """
+
+
+# # ABODDetector
+
+"""
+    ABODDetector(k = 5,
+                 metric = Euclidean(),
+                 algorithm = :kdtree,
+                 static = :auto,
+                 leafsize = 10,
+                 reorder = true,
+                 parallel = false,
+                 enhanced = false)
+
+Determine outliers based on the angles to its nearest neighbors. This implements the `FastABOD` variant described in
+the paper, that is, it uses the variance of angles to its nearest neighbors, not to the whole dataset, see [1]. 
+
+*Notice:* The scores are inverted, to conform to our notion that higher scores describe higher outlierness.
+
+Parameters
+----------
+$K_PARAM
+
+$KNN_PARAMS
+
+    enhanced::Bool
+When `enhanced=true`, it uses the enhanced ABOD (EABOD) adaptation proposed by [2].
+
+Examples (native interface)
+---------------------------
+$(SCORE_UNSUPERVISED("ABODDetector"))
+
+References
+----------
+[1] Kriegel, Hans-Peter; S hubert, Matthias; Zimek, Arthur (2008): Angle-based outlier detection in high-dimensional
+data.
+
+[2] Li, Xiaojie; Lv, Jian Cheng; Cheng, Dongdong (2015): Angle-Based Outlier Detection Algorithm with More Stable
+Relationships.
+
+$(mlj_header(ABODDetector))
+
+In MLJ or MLJBase, bind an instance `model` to data with:
+
+```
+    mach = machine(model, X)
+```
+
+where
+
+- `X`: any table of input features (eg, a `DataFrame`) whose columns each have
+  `Continuous` element scitype; check column scitypes with `schema(X)`
+
+Train the machine using `fit!(mach, rows=...)`.
+
+
+## Operations
+
+- `transform(mach, Xnew)`: Return a transformed vector of scores (element scitype
+  `Continuous`); here `Xnew` should have the same scitype as `X`.
+
+## Examples
+
+```julia
+using MLJ
+import OutlierDetectionData
+X, y = OutlierDetectionData.ODDS.load("annthyroid")
+
+ABODDetector = @load ABODDetector pkg=OutlierDetectionNeighbors
+detector = ABODDetector()
+mach = machine(detector, X) |> fit!
+test_scores = transform(mach, X)
+```
+"""
+ABODDetector


### PR DESCRIPTION
This is a only a proof of concept, not intended for merge. See https://github.com/OutlierDetectionJL/OutlierDetectionNeighbors.jl/pull/3#issuecomment-1326972662 .

Makes the docstring for `ABODDetector` and `ABODDetector` only MLJ-compliant by:

- moving existing docstring to new file models/docstrings.jl
- editting existing docstring: "Examples" -> "Examples (native interface)"
- adding the MLJ-specific stuff at the end (including MLJ "Examples" section)

The last makes use of `MLJModelInterface.doc_header(ModelType, augmented=true)` which requires MLJModelInterface 1.8, which has been added to the Project.toml

Here's how the result renders:
[docstring.pdf](https://github.com/OutlierDetectionJL/OutlierDetectionNeighbors.jl/files/10088237/docstring.pdf)
