### PR TITLE
Add generic MLJ interface tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,8 @@ julia = "1.6 - 1"
 
 [extras]
 OutlierDetectionTest = "66620973-d34b-445b-a614-4040704cad69"
+MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OutlierDetectionTest"]
+test = ["Test", "MLJTestInterface", "OutlierDetectionTest"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,20 @@
 using OutlierDetectionNeighbors
 using OutlierDetectionTest
 using Distances: Cityblock
+using MLJTestInterface
+using Test
+
+@testset "generic MLJ interface tests" begin
+    X = MLJTestInterface.make_regression() |> first
+    failures, summary = MLJTestInterface.test(
+        eval.(OutlierDetectionNeighbors.MODELS),
+        X;
+        mod=@__MODULE__,
+        verbosity=0, # bump to debug
+        throw=false, # set to true to debug
+    )
+    @test isempty(failures)
+end
 
 # Test the metadata of all exported detectors
 test_meta.(eval.(OutlierDetectionNeighbors.MODELS))


### PR DESCRIPTION
This PR adds generic MLJ interface tests provided by an new [extras] dependency MLJTestInterface.jl.

CI is currently failing, but hopefully resolution of https://github.com/OutlierDetectionJL/OutlierDetectionInterface.jl/issues/7 will resolve this.